### PR TITLE
Added _extref hooks to take in a v_g and theta_g as external states

### DIFF
--- a/DAIIB_1bus.m
+++ b/DAIIB_1bus.m
@@ -1,0 +1,6 @@
+function x = DAIIB_1bus(t,x,inverter_params, line_params, infbus_params)
+    %y = [1;0];
+    v_g = x(20);
+    theta_g = x(21);
+    x = [DAIIB_extref(t,x(1:19),[v_g,theta_g],inverter_params);
+         pf_eqs_DAIIB_1bus(x,[v_g,theta_g],inverter_params, line_params, infbus_params)];

--- a/DArcoEPSR122_1bus.m
+++ b/DArcoEPSR122_1bus.m
@@ -1,0 +1,113 @@
+clear all; %clc;
+%%Load System Models and Parameters
+addpath(genpath('device_models'))
+addpath('utils')
+parameters
+
+%% Set- up DAE Solver 
+options_dae = optimoptions('fsolve','Algorithm','trust-region-dogleg','StepTolerance', 1e-8,'FunctionTolerance', 1e-8,'MaxFunctionEvaluations',500000, 'MaxIterations',100000,'StepTolerance',1e-8,'OptimalityTolerance', 1e-8);
+x00_1bus = fsolve(@(x)DAIIB_1bus(0,x,inverter_params,line_params, infbus_params),[x0,1,0],options_dae);
+x00 = fsolve(@(x)DAIIB(0,x,inverter_params),x0,options_dae);
+
+%x00(20) = 1;
+%x00(21) = 0;
+M = eye(21);
+M(20,20)=0;
+M(21,21)=0;
+opts_1bus = odeset('RelTol',1e-8,'AbsTol',1e-8,'Mass',M);
+opts = odeset('RelTol',1e-8,'AbsTol',1e-8);%'Mass',M);
+
+% Time varying parameters need to be executed inside of ode solver so a
+% function can be embedded in the parameter structure passed to the solver.
+% Specific time varying statements can be defined at the bottom of the
+% script.
+inverter_params.tvar_fun = @p_ref_step;
+[t4_1_ext,y4_1_ext] = ode23t(@(t,x)DAIIB_1bus(t,x,inverter_params, line_params, infbus_params), [0:0.01:4], x00_1bus', opts_1bus);
+[t4_1,y4_1] = ode23t(@(t,x)DAIIB(t,x,inverter_params), [0:0.01:4], x00', opts);
+
+inverter_params.tvar_fun = @wg_ramp;
+[t4_2_ext,y4_2_ext] = ode23t(@(t,x)DAIIB_1bus(t,x,inverter_params, line_params, infbus_params), [0:0.01:4], x00_1bus', opts_1bus);
+[t4_2,y4_2] = ode23t(@(t,x)DAIIB(t,x,inverter_params), [0:0.01:4], x00', opts);
+
+%Figure 8: Plot power during step response. p = vod*iod+voq*ioq
+figure(8);
+plot(t4_1_ext,y4_1_ext(:,3).*y4_1_ext(:,11)+y4_1_ext(:,4).*y4_1_ext(:,12),t4_1_ext,y4_1(:,3).*y4_1(:,11)+y4_1(:,4).*y4_1(:,12));
+axis([0 4 0.4 0.8]);
+legend({'1-bus','\infty-bus'},'Location','east')
+title('Power [pu] (with stepped p ref)');
+ylabel('p [pu]');
+xlabel('Time [s]');
+
+%Figure 9: Plot w_vsm during step response.
+figure(9);
+plot(t4_1_ext,1+y4_1_ext(:,1),t4_1,1+y4_1(:,1));
+axis([0 4 .999 1.001]);
+legend({'1-bus','\infty-bus'},'Location','east')
+title('VSM speed (with stepped p ref)');
+ylabel('\omega_{VSM} [rad]')
+xlabel('Time [s]');
+
+%Figure 10: Plot d_w_vsm and d_theta_pll during step response.
+figure(10);
+subplot(2,1,1);
+plot(t4_1_ext,y4_1_ext(:,2),t4_1,y4_1(:,2));
+axis([0 4 .1 0.6]);
+legend({'1-bus','\infty-bus'},'Location','east')
+title('Phase angle orientation of VSM and PLL (with stepped p ref)');
+ylabel('\delta\theta_{VSM} [rad]');
+subplot(2,1,2);
+plot(t4_1_ext,y4_1_ext(:,18),t4_1,y4_1(:,18));
+axis([0 4 .05 0.2]);
+legend({'1-bus','\infty-bus'},'Location','east')
+ylabel('\delta\theta_{PLL} [rad]');
+xlabel('Time [s]');
+
+%Figure 11: Plot qm during step response. q = vod*iod+voq*ioq
+figure(11);
+%plot(t4_1,-y4_1(:,3).*y4_1(:,12)+y4_1(:,4).*y4_1(:,11));
+plot(t4_1_ext,y4_1_ext(:,19),t4_1,y4_1(:,19));
+axis([0 4 .015 .1]);
+legend({'1-bus','\infty-bus'},'Location','east')
+title('Reactive power (with stepped p ref)');
+ylabel('q_{m} [pu]')
+xlabel('Time [s]');
+
+%Figure 12: Plot power during freq ramp. p = vod*iod+voq*ioq
+figure(12);
+plot(t4_2_ext,y4_2_ext(:,3).*y4_2_ext(:,11)+y4_2_ext(:,4).*y4_2_ext(:,12),t4_2,y4_2(:,3).*y4_2(:,11)+y4_2(:,4).*y4_2(:,12));
+axis([0 4 0.4 0.7]);
+legend({'1-bus','\infty-bus'},'Location','east')
+title('Power [pu] (with freq ramp down)');
+ylabel('p [pu]');
+xlabel('Time [s]');
+
+%Figure 13: Plot converter current during freq ramp
+figure(13);
+plot(t4_2_ext,y4_2_ext(:,5),t4_2_ext,y4_2_ext(:,6),t4_2,y4_2(:,5),t4_2,y4_2(:,6));
+axis([0 4 -0.1 0.8]);
+legend({'i_{cv,d} 1-bus','i_{cv,q} 1-bus','i_{cv,d} \infty-bus','i_{cv,q} \infty-bus'},'Location','east')
+title('Converter current (with freq ramp down)');
+ylabel('i_{cv} [pu]');
+xlabel('Time [s]');
+
+%For D'Arco EPSR 122 (2015), Section 4.1
+%"Response to change in loading"
+function inverter_params = p_ref_step(t,inverter_params)
+    if t<1
+        inverter_params.p_ref = 0.5;
+    else
+        inverter_params.p_ref = 0.7;
+    end
+end
+
+%For D'Arco EPSR 122 (2015), Section 4.2
+%"Response to change in the grid frequency"
+function inverter_params = wg_ramp(t,inverter_params)
+    if t<1
+        inverter_params.wg = 1;
+    elseif (t<2)
+        inverter_params.wg = 1-(0.005*(t-1)); % At t=2, 1-0.005 = .995
+    else
+        inverter_params.wg = 0.995;
+    end
+end

--- a/device_models/DAIIB_extref.m
+++ b/device_models/DAIIB_extref.m
@@ -1,0 +1,45 @@
+function inverter_dxdt = DAIIB_extref(t,x,y,inverter_params)
+
+    inverter_params = inverter_params.tvar_fun(t, inverter_params);
+
+    v_g = y(1);
+    theta_g = y(2);
+    
+    %VSM variables
+    delta_w_vsm=x(1);
+    delta_theta_vsm=x(2);
+    
+    %VCO Variables
+    vod=x(3);
+    voq=x(4);
+    icvd=x(5);
+    icvq=x(6);
+    xi_d=x(7);
+    xi_q=x(8);
+    
+    %ICO Variables
+    gamma_d=x(9);
+    gamma_q=x(10);
+    iod=x(11);
+    ioq=x(12);
+    phi_d=x(13);
+    phi_q=x(14);
+
+    % PLL Variables
+    vpll_d=x(15);
+    vpll_q=x(16);
+    epsilon_pll=x(17);
+    delta_theta_pll=x(18);
+
+    % RPD Variable
+    qm=x(19);
+    
+inverter_dxdt=[
+    vsm_inertia(delta_w_vsm, [iod, vod, ioq, voq, vpll_d, vpll_q, epsilon_pll], inverter_params);
+    voltage_control([vod, voq, icvd, icvq, xi_d, xi_q], [iod, ioq,phi_d, phi_q, gamma_d, gamma_q, qm, delta_w_vsm], inverter_params);
+    current_control_extref([iod, ioq,  phi_d, phi_q], [vod, voq,  icvd, icvq,  xi_d, xi_q, qm, delta_theta_vsm, delta_w_vsm, v_g, theta_g], inverter_params);
+    PLL_extref([vpll_d, vpll_q, epsilon_pll, delta_theta_pll], [vod, voq,  delta_theta_vsm, theta_g], inverter_params);
+    reactive_power_droop(qm, [iod, vod, ioq, voq], inverter_params);
+    ];
+
+    

--- a/device_models/inverter/PLL_extref.m
+++ b/device_models/inverter/PLL_extref.m
@@ -1,0 +1,42 @@
+function f = PLL_extref(x,y, params)
+
+
+    vpll_d = x(1); 
+    vpll_q = x(2);
+    epsilon_pll = x(3);
+    delta_theta_pll = x(4);
+    
+    vod = y(1);
+    voq = y(2);
+    delta_theta_vsm = y(3);
+    theta_g = y(4);    
+    
+   %get parameters
+   
+    wlp = params.wlp; % PLL filter in rad/s
+    kp_pll = params.kp_pll; % PLL proportional gain
+    ki_pll = params.ki_pll; % PLL integraql gain 
+    wb = params.wb;
+    wg = params.wg;
+
+f = [
+      %d(vpll,d)/dt = 
+      wlp*vod*cos(delta_theta_pll-delta_theta_vsm+theta_g)+...
+      wlp*voq*sin(delta_theta_pll-delta_theta_vsm+theta_g)-...
+      wlp*vpll_d;
+      
+      %d(vpll,q)/dt = 
+      -wlp*vod*sin(delta_theta_pll-delta_theta_vsm+theta_g)+...
+      wlp*voq*cos(delta_theta_pll-delta_theta_vsm+theta_g)-...
+      wlp*vpll_q;
+      
+      %d(epsilon_pll)/dt = 
+      atan(vpll_q/vpll_d);
+      
+       %delta_theta_pll = 
+       wb*kp_pll*atan(vpll_q/vpll_d)+...
+       wb*ki_pll*epsilon_pll;
+       
+       ];
+end
+

--- a/device_models/inverter/current_control_extref.m
+++ b/device_models/inverter/current_control_extref.m
@@ -1,0 +1,85 @@
+function f = current_control(x,y,params)
+
+
+    iod = x(1);
+    ioq = x(2);  
+    phi_d = x(3);
+    phi_q = x(4);
+    
+    vod = y(1); 
+    voq = y(2); 
+    icvd = y(3); 
+    icvq = y(4);   
+    xi_d = y(5); 
+    xi_q = y(6);
+    qm = y(7); 
+    delta_theta_vsm = y(8); 
+    delta_w_vsm = y(9); 
+    v_g = y(10);
+    theta_g = y(11);
+    
+ %get parameters
+ 
+    kpv = params.kpv; % Voltage controller gain
+    kiv = params.kiv; % Voltage controller gain
+    wb = params.wb; 
+    wg = params.wg; 
+    cf = params.cf; % Filter capacitance in p.u.
+    kffi = params.kffi;
+    lg = params.lg; % Grid inductance in p.u.
+    rg = params.rg; % Grid resistance in p.u.    
+    wad = params.wad; % Active damping filte
+    rv = params.rv;
+    lv = params.lv;
+    kq = params.kq;
+    q_ref = params.q_ref;
+    v_ref = params.v_ref;
+    vg = params.vg;
+f = [
+    
+     %d(gamma_d)/dt = 
+      -kpv*vod-...
+      cf*wg*voq-...
+      icvd+...
+      (kffi-kpv*rv)*iod+...
+      kpv*lv*wg*ioq+...
+      kiv*xi_d-...
+      kpv*kq*qm+... %changed sign of kpv*kq*qm to -
+      kpv*lv*ioq*delta_w_vsm-...
+      cf*voq*delta_w_vsm+... *changed sign of cf*voq*delta_w_vsm to -
+      kpv*kq*q_ref+... *changed sign of kpv*kq*q_ref to +
+      kpv*v_ref; 
+      
+      %d(gamma,q)/dt = 
+      cf*wg*vod-...
+      kpv*voq-...
+      icvq-...
+      kpv*lv*wg*iod+...
+      (kffi-kpv*rv)*ioq+...
+      kiv*xi_q-...
+      kpv*lv*iod*delta_w_vsm+...
+      cf*vod*delta_w_vsm; 
+      
+      %d(io,d)/dt= 
+      wb*vod/lg-...
+      wb*rg*iod/lg+...
+      wb*wg*ioq-... 
+      wb*v_g*cos(delta_theta_vsm-theta_g)/lg; % Paper eqn error: should be (-) term
+      
+      %d(io,q)/dt = 
+      wb*voq/lg-...
+      wb*wg*iod-...
+      wb*rg*ioq/lg+...
+      wb*v_g*sin(delta_theta_vsm-theta_g)/lg; 
+
+      %d(phi_d)/dt= 
+      wad*vod-wad*phi_d; 
+      
+      %d(phi_q)/dt =
+      wad*voq-wad*phi_q; 
+
+
+      ];
+      
+end
+

--- a/device_models/network/pf_eqs_DAIIB_1bus.m
+++ b/device_models/network/pf_eqs_DAIIB_1bus.m
@@ -1,0 +1,20 @@
+function [vars] = pf_eqs_DAIIB_1bus(x, y, inverter_params, line_params, infbus_params)
+    
+    Q_g = x(1);
+    theta = y(2); 
+    V_g = y(1);
+    
+    V_inf = infbus_params.V_inf;
+    theta_inf = infbus_params.Theta_inf;
+    
+    Xl = line_params.Xl;
+    Xth = infbus_params.Xth;
+    X= Xl;%+Xth;
+    
+    Pd = inverter_params.p_ref;
+    
+    P_res =  Pd - V_inf*V_g*sin(theta-theta_inf)/X;
+    Q_res =  Q_g - (V_g^2/(X) - V_inf*V_g*cos(theta-theta_inf)/X);
+    
+    vars = [P_res, Q_res]';
+end


### PR DESCRIPTION
_extref version of files now allows v_g and theta_g as states that can be pulled in from power flow

Added a new script called DArcoEPSR122_1bus that runs the DAIIB with a single additional line connecting v_g to the infinite bus, s.t. v_g is no longer fixed at 1 and theta_g is no longer fixed at 0 (though v_inf and theta_inf are, respectively). This requires modifications to current_control and PLL, with the _extref suffix corresponding to the new functions in the DAIIB_extref configuration. Plots both the original DArco results against the one with the new line added to the infinite bus.

Leverages a version of Jose's pf_eqs in DAIIB_1bus, including line parameters, but using the inverter instead of the machine and no Xth.

fsolve seems to init even with a rough guess of [1,0] for [v_g, theta_g] and with DAE.